### PR TITLE
Fix Nerd Font icon width

### DIFF
--- a/lemonbar.c
+++ b/lemonbar.c
@@ -244,8 +244,12 @@ int xft_char_width (uint16_t ch, font_t *cur_font)
         XftGlyphExtents (dpy, cur_font->xft_ft, &glyph, 1, &gi);
         XftFontUnloadGlyphs (dpy, cur_font->xft_ft, &glyph, 1);
         xft_char[slot] = ch;
-        xft_width[slot] = gi.xOff;
-        return gi.xOff;
+        if (gi.xOff >= gi.width) {
+            xft_width[slot] = gi.xOff;
+        } else {
+            xft_width[slot] = gi.width;
+        }
+        return xft_width[slot];
     } else if (xft_char[slot] == ch)
         return xft_width[slot];
     else


### PR DESCRIPTION
I'm not sure where to make this PR so let me know if this is the wrong place! I don't know if this is the most active fork of krypt-n's initial fork but I have a little change that makes Nerd Font icons display correctly.

There's also another commit from krypt-n's fork which isn't in this one but I've left that out to make this change super simple.

Command:
```sh
echo -e "\ufa7d test" | ./lemonbar -p -B "#000000" -F "#ffffff" -f "mononoki Nerd Font"
```

Before: 
![before](https://i.imgur.com/YmMy0hk.png)

After:
![after](https://i.imgur.com/eZ2XCHF.png)